### PR TITLE
gdrive set path to client secret

### DIFF
--- a/sqlgsheet/gdrive.py
+++ b/sqlgsheet/gdrive.py
@@ -144,10 +144,9 @@ def get_file_parent_folder_ids(file_id):
 def get_credentials():
     #current_path = os.path.abspath('')
     #file_path = current_path[:current_path.find('PyTools')] + 'PyTools\\GsheetsAPI\\'
-    file_path = os.path.dirname(__file__) + '\\'
+    #file_path = os.path.dirname(__file__) + '\\'
     #credentials = service_account.Credentials.from_service_account_file(file_path + CLIENT_SECRET_FILE,scopes=SCOPES)
-    credentials = ServiceAccountCredentials.from_json_keyfile_name(
-        file_path + CLIENT_SECRET_FILE, SCOPES)
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(CLIENT_SECRET_FILE, SCOPES)
     return credentials
 
 


### PR DESCRIPTION
*User data*

*problem description*

Reading user data was unsuccessful on the 1st attempt because layers are imported into a separate directory /opt from the default runtime directory /var/task

*Proposed solution*

update the sqlgsheet package 1.3.2 to be able to configure the user data with reference to file path

/lambda_handler.py

```python
from sqlgsheet import database as db
from sqlgsheet import gdrive as gd

USER_DATA_DIR = '/opt/user_data'

def hlambda_handler(event, context): 
    db.set_user_data(
        gsheet_config=USER_DATA_DIR + '/gsheet_config.json'
        client_secret=USER_DATA_DIR + '/client_secret.json'        
        mysql_credentials=USER_DATA_DIR + '/mysql_credentials.json'
    )
    gd.CLIENT_SECRET_FILE = USER_DATA_DIR + '/client_secret.json'
    db.load()
    events = db.get_table('event')
    print('first record:{event}'.format(events.iloc[0]))
    ...
```

*sqlgsheet 1.3.2 update set_user_data()*

/gdrive.py

```python
...
CLIENT_SECRET_FILE ='client_secret.json'   
...
def get_credentials():
    #current_path = os.path.abspath('')
    #file_path = current_path[:current_path.find('PyTools')] + 'PyTools\\GsheetsAPI\\'
    #file_path = os.path.dirname(__file__) + '\\'
    #credentials = service_account.Credentials.from_service_account_file(file_path + CLIENT_SECRET_FILE,scopes=SCOPES)
    credentials = ServiceAccountCredentials.from_json_keyfile_name(CLIENT_SECRET_FILE, SCOPES)
    return credentials
```

/gsheet.py

```python
...
CLIENT_SECRET_FILE ='client_secret.json'   #must be located in the same directory
...
def get_credentials():
    #current_path = os.path.abspath('')
    #file_path = current_path[:current_path.find('PyTools')] + 'PyTools\\GsheetsAPI\\'
    #file_path = os.path.join(os.path.dirname(__file__), CLIENT_SECRET_FILE)
    #credentials = service_account.Credentials.from_service_account_file(file_path + CLIENT_SECRET_FILE,scopes=SCOPES)
    credentials = ServiceAccountCredentials.from_json_keyfile_name(CLIENT_SECRET_FILE, SCOPES)
    return credentials
```

/mysql.py

```python
...
PATH_MYSQL_CRED = 'mysql_credentials.json'
...
def load_config():
    global MYSQL_CONFIG, MYSQL_CREDENTIALS
    MYSQL_CREDENTIALS = json.load(open(PATH_MYSQL_CRED))
```

/database.py

```python
...
from typing import Optional
...
PATH_GSHEET_CONFIG = 'gsheet_config.json'
...
def load_config():
    global CONFIG, GSHEET_CONFIG
    GSHEET_CONFIG = json.load(open(PATH_GSHEET_CONFIG))
...
def set_user_data(gsheet_config: Optional[str] = None,
                  client_secret: Optional[str] = None,
                  mysql_credentials: Optional[str] = None) -> None:
    global PATH_GSHEET_CONFIG
    if client_secret:
        gs.CLIENT_SECRET_FILE = gsheet_config
    if mysql_credentials:
        mysql.PATH_MYSQL_CRED = mysql_credentials
    if gsheet_config:
        PATH_GSHEET_CONFIG = gsheet_config
```